### PR TITLE
Correct RBV for both rising trig mode

### DIFF
--- a/merlinApp/Db/merlin.template
+++ b/merlinApp/Db/merlin.template
@@ -46,7 +46,7 @@ record(mbbi,"$(P)$(R)TriggerMode_RBV") {
     field(THVL,"3")
     field(THST,"Trigger start falling")
     field(FRVL,"4")
-    field(FRST,"Trigger both rising ")
+    field(FRST,"Trigger both rising")
     field(FVVL,"5")
     field(FVST,"Software")
 }


### PR DESCRIPTION
Whitespace removed from end of mbbi field FRST 'Trigger both rising' for TriggerMode_RBV. (Since was only present in RBV, comparisons would fail.)