### PR TITLE
The new PV for board temperature (added in PR#15) is added to the edl screen here

### DIFF
--- a/merlinApp/op/edl/merlinDetector.edl
+++ b/merlinApp/op/edl/merlinDetector.edl
@@ -4,9 +4,9 @@ major 4
 minor 0
 release 1
 x 1069
-y 100
+y 509
 w 395
-h 820
+h 840
 font "arial-bold-r-12.0"
 ctlFont "arial-bold-r-12.0"
 btnFont "arial-bold-r-12.0"
@@ -24,21 +24,6 @@ snapToGrid
 gridSize 5
 endScreenProperties
 
-# (Rectangle)
-object activeRectangleClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 5
-y 485
-w 380
-h 330
-lineColor index 14
-fill
-fillColor index 3
-endObjectProperties
-
 # (Embedded Window)
 object activePipClass
 beginObjectProperties
@@ -46,9 +31,9 @@ major 4
 minor 1
 release 0
 x 5
-y 490
-w 380
-h 160
+y 475
+w 385
+h 360
 fgColor index 14
 bgColor index 3
 topShadowColor index 1
@@ -81,255 +66,5 @@ displayFileName {
   0 "NDPluginBase"
 }
 noScroll
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 5
-y 475
-w 91
-h 13
-font "arial-medium-r-12.0"
-fgColor index 14
-bgColor index 5
-value {
-  "  Medipix driver  "
-}
-autoSize
-border
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 105
-y 750
-w 275
-h 20
-controlPv "$(P)$(R)StringToServer_RBV"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-10.0"
-fontAlign "center"
-endObjectProperties
-
-# (Textupdate)
-object TextupdateClass
-beginObjectProperties
-major 10
-minor 0
-release 0
-x 105
-y 790
-w 275
-h 20
-controlPv "$(P)$(R)StringFromServer_RBV"
-fgColor index 16
-fgAlarm
-bgColor index 10
-fill
-font "arial-bold-r-10.0"
-fontAlign "center"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 750
-w 90
-h 20
-font "arial-bold-r-12.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "To labview:"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 10
-y 790
-w 95
-h 20
-font "arial-bold-r-12.0"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "From labview:"
-}
-endObjectProperties
-
-# (Menu Button)
-object activeMenuButtonClass
-beginObjectProperties
-major 4
-minor 0
-release 0
-x 255
-y 715
-w 110
-h 20
-fgColor index 25
-bgColor index 3
-inconsistentColor index 0
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(P)$(R)ArrayCallbacks"
-indicatorPv "$(P)$(R)ArrayCallbacks_RBV"
-font "arial-bold-r-12.0"
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 140
-y 715
-w 105
-h 20
-font "arial-bold-r-12.0"
-fontAlign "right"
-fgColor index 14
-bgColor index 3
-useDisplayBg
-value {
-  "Callbacks:"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 185
-y 690
-w 147
-h 13
-font "arial-bold-r-12.0"
-fontAlign "center"
-fgColor index 19
-bgColor index 3
-useDisplayBg
-visMin "1"
-visMax "2"
-value {
-  "Data Channel Connected"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 180
-y 685
-w 185
-h 20
-font "arial-bold-r-12.0"
-fontAlign "center"
-fgColor index 21
-bgColor index 35
-visPv "$(P)$(R)LabviewAsynData.CNCT"
-visMin "0"
-visMax "1"
-value {
-  "Data Channel Err - reboot IOC!"
-}
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 185
-y 665
-w 184
-h 13
-font "arial-bold-r-12.0"
-fontAlign "center"
-fgColor index 19
-bgColor index 3
-useDisplayBg
-visMin "1"
-visMax "2"
-value {
-  "Command Channel Connected"
-}
-autoSize
-endObjectProperties
-
-# (Static Text)
-object activeXTextClass
-beginObjectProperties
-major 4
-minor 1
-release 1
-x 180
-y 660
-w 185
-h 20
-font "arial-bold-r-12.0"
-fontAlign "center"
-fgColor index 21
-bgColor index 35
-visPv "$(P)$(R)LabviewAsynCmd.CNCT"
-visMin "0"
-visMax "1"
-value {
-  "Cmd Channel Err - reboot IOC!"
-}
-endObjectProperties
-
-# (Message Button)
-object activeMessageButtonClass
-beginObjectProperties
-major 4
-minor 1
-release 0
-x 15
-y 710
-w 105
-h 25
-fgColor index 20
-onColor index 4
-offColor index 3
-topShadowColor index 1
-botShadowColor index 11
-controlPv "$(P)$(R)Reset"
-pressValue "1"
-onLabel "Reset"
-offLabel "Reset"
-3d
-useEnumNumeric
-font "arial-bold-r-12.0"
 endObjectProperties
 

--- a/merlinApp/op/edl/merlinEmbedded.edl
+++ b/merlinApp/op/edl/merlinEmbedded.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 686
-y 857
-w 360
-h 180
+x 1673
+y 693
+w 381
+h 346
 font "arial-bold-r-12.0"
 ctlFont "arial-bold-r-12.0"
 btnFont "arial-bold-r-12.0"
@@ -25,6 +25,36 @@ snapToGrid
 gridSize 5
 endScreenProperties
 
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 5
+w 380
+h 180
+lineColor index 14
+fill
+fillColor index 3
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 185
+w 380
+h 160
+lineColor index 14
+fill
+fillColor index 3
+endObjectProperties
+
 # (Related Display)
 object relatedDisplayClass
 beginObjectProperties
@@ -32,7 +62,7 @@ major 4
 minor 4
 release 0
 x 5
-y 135
+y 160
 w 105
 h 20
 fgColor index 14
@@ -55,7 +85,7 @@ major 4
 minor 0
 release 0
 x 270
-y 135
+y 160
 w 85
 h 20
 
@@ -68,7 +98,7 @@ major 4
 minor 0
 release 0
 x 270
-y 135
+y 160
 w 85
 h 20
 fgColor index 25
@@ -94,7 +124,7 @@ major 4
 minor 1
 release 1
 x 165
-y 135
+y 160
 w 100
 h 20
 font "arial-bold-r-12.0"
@@ -113,7 +143,7 @@ major 4
 minor 1
 release 1
 x 165
-y 110
+y 135
 w 90
 h 20
 font "arial-bold-r-12.0"
@@ -132,7 +162,7 @@ major 4
 minor 0
 release 0
 x 270
-y 110
+y 135
 w 85
 h 20
 
@@ -145,7 +175,7 @@ major 4
 minor 0
 release 0
 x 270
-y 110
+y 135
 w 85
 h 20
 fgColor index 25
@@ -171,7 +201,7 @@ major 4
 minor 0
 release 0
 x 270
-y 85
+y 110
 w 85
 h 20
 
@@ -184,7 +214,7 @@ major 4
 minor 0
 release 0
 x 270
-y 85
+y 110
 w 85
 h 20
 fgColor index 25
@@ -210,7 +240,7 @@ major 4
 minor 1
 release 1
 x 165
-y 85
+y 110
 w 90
 h 20
 font "arial-bold-r-12.0"
@@ -229,7 +259,7 @@ major 4
 minor 4
 release 0
 x 5
-y 90
+y 115
 w 105
 h 20
 fgColor index 14
@@ -252,7 +282,7 @@ major 10
 minor 0
 release 0
 x 245
-y 5
+y 10
 w 110
 h 20
 controlPv "$(P)$(R)ThresholdEnergy0_RBV"
@@ -271,7 +301,7 @@ major 4
 minor 6
 release 0
 x 125
-y 5
+y 10
 w 110
 h 20
 controlPv "$(P)$(R)ThresholdEnergy0"
@@ -296,7 +326,7 @@ major 4
 minor 1
 release 1
 x 5
-y 5
+y 10
 w 110
 h 20
 font "arial-bold-r-12.0"
@@ -315,7 +345,7 @@ major 10
 minor 0
 release 0
 x 245
-y 30
+y 35
 w 110
 h 20
 controlPv "$(P)$(R)ThresholdEnergy1_RBV"
@@ -334,7 +364,7 @@ major 4
 minor 6
 release 0
 x 125
-y 30
+y 35
 w 110
 h 20
 controlPv "$(P)$(R)ThresholdEnergy1"
@@ -359,7 +389,7 @@ major 4
 minor 1
 release 1
 x 5
-y 30
+y 35
 w 110
 h 20
 font "arial-bold-r-12.0"
@@ -378,7 +408,7 @@ major 10
 minor 0
 release 0
 x 245
-y 55
+y 60
 w 110
 h 20
 controlPv "$(P)$(R)OperatingEnergy_RBV"
@@ -397,7 +427,7 @@ major 4
 minor 6
 release 0
 x 125
-y 55
+y 60
 w 110
 h 20
 controlPv "$(P)$(R)OperatingEnergy"
@@ -422,7 +452,7 @@ major 4
 minor 1
 release 1
 x 5
-y 55
+y 60
 w 110
 h 20
 font "arial-bold-r-12.0"
@@ -432,5 +462,293 @@ useDisplayBg
 value {
   "Operating E (keV):"
 }
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 125
+y 85
+w 230
+h 20
+controlPv "$(P)$(R)BoardTemperature_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 5
+y 85
+w 110
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Board Temp (°C):"
+}
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 280
+w 275
+h 20
+controlPv "$(P)$(R)StringToServer_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-10.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 320
+w 275
+h 20
+controlPv "$(P)$(R)StringFromServer_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-10.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 280
+w 90
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "To labview:"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 320
+w 95
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "From labview:"
+}
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 250
+y 245
+w 110
+h 20
+fgColor index 25
+bgColor index 3
+inconsistentColor index 0
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)ArrayCallbacks"
+indicatorPv "$(P)$(R)ArrayCallbacks_RBV"
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 135
+y 245
+w 105
+h 20
+font "arial-bold-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Callbacks:"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 220
+w 147
+h 13
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 19
+bgColor index 3
+useDisplayBg
+visMin "1"
+visMax "2"
+value {
+  "Data Channel Connected"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 215
+w 185
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 21
+bgColor index 35
+visPv "$(P)$(R)LabviewAsynData.CNCT"
+visMin "0"
+visMax "1"
+value {
+  "Data Channel Err - reboot IOC!"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 195
+w 184
+h 13
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 19
+bgColor index 3
+useDisplayBg
+visMin "1"
+visMax "2"
+value {
+  "Command Channel Connected"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 190
+w 185
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 21
+bgColor index 35
+visPv "$(P)$(R)LabviewAsynCmd.CNCT"
+visMin "0"
+visMax "1"
+value {
+  "Cmd Channel Err - reboot IOC!"
+}
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 10
+y 240
+w 105
+h 25
+fgColor index 20
+onColor index 4
+offColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)Reset"
+pressValue "1"
+onLabel "Reset"
+offLabel "Reset"
+3d
+useEnumNumeric
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 0
+y 0
+w 91
+h 13
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 5
+value {
+  "  Medipix driver  "
+}
+autoSize
+border
 endObjectProperties
 

--- a/merlinApp/op/edl/merlinQuadEmbedded.edl
+++ b/merlinApp/op/edl/merlinQuadEmbedded.edl
@@ -3,10 +3,10 @@ beginScreenProperties
 major 4
 minor 0
 release 1
-x 343
-y 128
-w 360
-h 80
+x 2285
+y 702
+w 381
+h 242
 font "arial-bold-r-12.0"
 ctlFont "arial-bold-r-12.0"
 btnFont "arial-bold-r-12.0"
@@ -25,6 +25,21 @@ snapToGrid
 gridSize 5
 endScreenProperties
 
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 5
+w 380
+h 80
+lineColor index 14
+fill
+fillColor index 3
+endObjectProperties
+
 # (Group)
 object activeGroupClass
 beginObjectProperties
@@ -32,7 +47,7 @@ major 4
 minor 0
 release 0
 x 210
-y 10
+y 20
 w 140
 h 20
 
@@ -45,7 +60,7 @@ major 4
 minor 0
 release 0
 x 210
-y 10
+y 20
 w 140
 h 20
 fgColor index 25
@@ -71,7 +86,7 @@ major 4
 minor 1
 release 1
 x 165
-y 10
+y 20
 w 60
 h 20
 font "arial-bold-r-12.0"
@@ -90,7 +105,7 @@ major 4
 minor 4
 release 0
 x 25
-y 10
+y 20
 w 105
 h 20
 fgColor index 14
@@ -113,7 +128,7 @@ major 4
 minor 4
 release 0
 x 25
-y 45
+y 50
 w 105
 h 20
 fgColor index 14
@@ -127,5 +142,308 @@ numDsps 1
 displayFileName {
   0 "merlin8Thresholds.edl"
 }
+endObjectProperties
+
+# (Rectangle)
+object activeRectangleClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 0
+y 85
+w 380
+h 160
+lineColor index 14
+fill
+fillColor index 3
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 180
+w 275
+h 20
+controlPv "$(P)$(R)StringToServer_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-10.0"
+fontAlign "center"
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 100
+y 220
+w 275
+h 20
+controlPv "$(P)$(R)StringFromServer_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-10.0"
+fontAlign "center"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 180
+w 90
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "To labview:"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 10
+y 220
+w 95
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "From labview:"
+}
+endObjectProperties
+
+# (Menu Button)
+object activeMenuButtonClass
+beginObjectProperties
+major 4
+minor 0
+release 0
+x 250
+y 145
+w 110
+h 20
+fgColor index 25
+bgColor index 3
+inconsistentColor index 0
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)ArrayCallbacks"
+indicatorPv "$(P)$(R)ArrayCallbacks_RBV"
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 135
+y 145
+w 105
+h 20
+font "arial-bold-r-12.0"
+fontAlign "right"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Callbacks:"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 120
+w 147
+h 13
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 19
+bgColor index 3
+useDisplayBg
+visMin "1"
+visMax "2"
+value {
+  "Data Channel Connected"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 115
+w 185
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 21
+bgColor index 35
+visPv "$(P)$(R)LabviewAsynData.CNCT"
+visMin "0"
+visMax "1"
+value {
+  "Data Channel Err - reboot IOC!"
+}
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 95
+w 184
+h 13
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 19
+bgColor index 3
+useDisplayBg
+visMin "1"
+visMax "2"
+value {
+  "Command Channel Connected"
+}
+autoSize
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 175
+y 90
+w 185
+h 20
+font "arial-bold-r-12.0"
+fontAlign "center"
+fgColor index 21
+bgColor index 35
+visPv "$(P)$(R)LabviewAsynCmd.CNCT"
+visMin "0"
+visMax "1"
+value {
+  "Cmd Channel Err - reboot IOC!"
+}
+endObjectProperties
+
+# (Message Button)
+object activeMessageButtonClass
+beginObjectProperties
+major 4
+minor 1
+release 0
+x 10
+y 140
+w 105
+h 25
+fgColor index 20
+onColor index 4
+offColor index 3
+topShadowColor index 1
+botShadowColor index 11
+controlPv "$(P)$(R)Reset"
+pressValue "1"
+onLabel "Reset"
+offLabel "Reset"
+3d
+useEnumNumeric
+font "arial-bold-r-12.0"
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 0
+y 0
+w 91
+h 13
+font "arial-medium-r-12.0"
+fgColor index 14
+bgColor index 5
+value {
+  "  Medipix driver  "
+}
+autoSize
+border
+endObjectProperties
+
+# (Static Text)
+object activeXTextClass
+beginObjectProperties
+major 4
+minor 1
+release 1
+x 165
+y 50
+w 110
+h 20
+font "arial-bold-r-12.0"
+fgColor index 14
+bgColor index 3
+useDisplayBg
+value {
+  "Board Temp (°C):"
+}
+endObjectProperties
+
+# (Textupdate)
+object TextupdateClass
+beginObjectProperties
+major 10
+minor 0
+release 0
+x 275
+y 50
+w 75
+h 20
+controlPv "$(P)$(R)BoardTemperature_RBV"
+fgColor index 16
+fgAlarm
+bgColor index 10
+fill
+font "arial-bold-r-12.0"
+fontAlign "center"
 endObjectProperties
 


### PR DESCRIPTION
The new PV for board temperature (added in PR#15) is added to the edl screen in this PR (just edl as I don't have experience of other operator interfaces). edl screen layout also cleaned up:
All Merlin specific items moved to embedded screen, with merlinDetector.edl now only including ADBase.edl and merlin[Quad]Embedded.edl.